### PR TITLE
Change Hex packagae manager rake import task to async

### DIFF
--- a/app/models/package_manager/hex.rb
+++ b/app/models/package_manager/hex.rb
@@ -24,9 +24,9 @@ module PackageManager
     def self.project_names
       page = 1
       projects = []
-      while page < 1000
+      loop do
         r = get("https://hex.pm/api/packages?page=#{page}")
-        break if r == []
+        break if r.nil? || r == []
 
         projects += r
         page += 1

--- a/lib/tasks/download.rake
+++ b/lib/tasks/download.rake
@@ -142,7 +142,7 @@ namespace :download do
 
   desc "Download all Hex packages"
   task hex_all: :environment do
-    PackageManager::Hex.import
+    PackageManager::Hex.import_async
   end
 
   desc "Download recent Homebrew packages asynchronously"


### PR DESCRIPTION
Change Hex package manager rake import task to async.
Fix incomplete projects list error when fetching projects from package manager API.

https://gitlab.com/openteams/OpenTeams-Data/-/issues/239