### PR TITLE
Rescue NoMethod error when there are no manifest dependencies

### DIFF
--- a/app/models/concerns/repo_manifests.rb
+++ b/app/models/concerns/repo_manifests.rb
@@ -65,6 +65,8 @@ module RepoManifests
         })
       end
     end
+  rescue NoMethodError => e
+    Rails.logger.error e.message
   end
 
   def delete_old_manifests(new_manifests)


### PR DESCRIPTION
Fix NoMethod error when there are no manifest dependencies.

https://openteams.atlassian.net/browse/OI-247?atlOrigin=eyJpIjoiYTA2OGU1ZTEwZDVlNDQxM2EwMzFiYzE4ZDgwMWExM2EiLCJwIjoiaiJ9