### PR TITLE
Index display name as raw to enable aggregated results

### DIFF
--- a/app/models/concerns/project_search.rb
+++ b/app/models/concerns/project_search.rb
@@ -43,7 +43,9 @@ module ProjectSearch
         indexes :dependents_count, type: 'integer'
         indexes :dependent_repos_count, type: 'integer'
         indexes :contributions_count, type: 'integer'
-        indexes :display_name, type: 'text', analyzer: 'keyword'
+        indexes :display_name, type: 'text', analyzer: 'keyword' do
+          indexes :raw, type: 'keyword'
+        end
         indexes :project_group, type: 'integer'
       end
     end


### PR DESCRIPTION
Index project display_name as a raw field in Elastic Search to enable aggregated search results.